### PR TITLE
Update php-amqplib to renamed project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require": {
       "php": ">= 5.3.0",
-      "videlalvaro/php-amqplib": "2.5.*",
+      "php-amqplib/php-amqplib": "~2.5",
       "monolog/monolog": "1.*"
   },
   "autoload": {


### PR DESCRIPTION
The videlalvaro/php-amqplib was renamed to php-amqplib/php-amqplib
sometime last year . The new project offers the same base tags
as the old one, for the most parts it's just a rename.

This needs fixing in syrpc-php since downstream projects can't
currently choose to upgrade to the latest and greatest version of
the lib. It is hoped that this will also fix some of the rabbitmq
issues cropping up when using the lib against old-ish versions of
rabbitmq.